### PR TITLE
1.21.11 Hotfix

### DIFF
--- a/src/main/java/net/cyvfabric/event/CommandInitializer.java
+++ b/src/main/java/net/cyvfabric/event/CommandInitializer.java
@@ -53,9 +53,6 @@ public class CommandInitializer  {
             //register the base command
             LiteralCommandNode<FabricClientCommandSource> baseCommand = dispatcher.register(
                     ClientCommandManager.literal("cyv")
-                    .requires(source -> source.getPlayer().permissions().hasPermission(
-                            new Permission.HasCommandLevel(PermissionLevel.ALL)
-                    ))
                     .executes(context -> {
                         CyvFabric.sendChatMessage("For more info use /cyv help"); //no args
                         return 1;

--- a/src/main/java/net/cyvfabric/hud/HUDManager.java
+++ b/src/main/java/net/cyvfabric/hud/HUDManager.java
@@ -1,5 +1,6 @@
 package net.cyvfabric.hud;
 
+import com.mojang.blaze3d.platform.Window;
 import net.cyvfabric.command.mpk.CommandMacro;
 import net.cyvfabric.gui.GuiMPK;
 import net.cyvfabric.gui.GuiModConfig;
@@ -10,13 +11,13 @@ import net.cyvfabric.hud.nonlabels.TogglesprintHUD;
 import net.cyvfabric.hud.structure.DraggableHUDElement;
 import net.cyvfabric.hud.structure.ScreenPosition;
 import net.fabricmc.fabric.api.client.rendering.v1.hud.HudElementRegistry;
+import net.fabricmc.fabric.api.client.rendering.v1.hud.VanillaHudElements;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.Options;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screens.ChatScreen;
 import net.minecraft.client.gui.screens.inventory.ContainerScreen;
-import com.mojang.blaze3d.platform.Window;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,7 +26,7 @@ public class HUDManager {
     private static Minecraft mc = Minecraft.getInstance();
 
     public static void init() { //initialize and create eventlistener
-        HudElementRegistry.addLast(RenderLayers.LABELS_LAYER, HUDManager::render);
+        HudElementRegistry.attachElementBefore(VanillaHudElements.PLAYER_LIST, RenderLayers.LABELS_LAYER, HUDManager::render);
 
         registeredRenderers.add(new DirectionHUD());
         registeredRenderers.add(new TogglesprintHUD());


### PR DESCRIPTION
- Changes labels to be rendered below the TAB player list
- Removes useless permission requirement to /cyv as it is a client command